### PR TITLE
Merged AccessKit Disable GIFs dev branch

### DIFF
--- a/src/features/accesskit.json
+++ b/src/features/accesskit.json
@@ -14,6 +14,15 @@
       "label": "Pause GIFs until they are hovered over",
       "default": false
     },
+    "disable_gifs_loading_mode": {
+      "type": "select",
+      "label": "Download paused GIFs:",
+      "options": [
+        { "value": "immediate", "label": "immediately" },
+        { "value": "delayed", "label": "when hovered" }
+      ],
+      "default": "immediate"
+    },
     "boring_tag_chiclets": {
       "type": "checkbox",
       "label": "De-animate the Changes/Shop/etc. links carousel",

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -10,6 +10,7 @@ const pausedContentVar = '--xkit-paused-gif-content';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
+const hasLoadingContentImageAttribute = 'data-paused-gif-content-loading';
 const loadingBackgroundImageAttribute = 'data-paused-gif-background-loading';
 
 let enabledTimestamp;
@@ -67,6 +68,12 @@ img[style*="${pausedContentVar}"]:not(${hovered}) {
   background-image: var(${pausedBackgroundImageVar}) !important;
 }
 
+[${hasLoadingContentImageAttribute}] > img:not(${hovered}) {
+  filter: blur(40px);
+}
+[${hasLoadingContentImageAttribute}] {
+  contain: paint;
+}
 [${loadingBackgroundImageAttribute}]:not(${hovered})::before {
   content: "";
   backdrop-filter: blur(40px);
@@ -142,9 +149,11 @@ const processGifs = function (gifElements) {
 };
 
 const pauseContentGif = async function (gifElement) {
+  Date.now() - enabledTimestamp >= 100 && gifElement.parentElement?.setAttribute(hasLoadingContentImageAttribute, '');
+  addLabel(gifElement);
   await loaded(gifElement);
   gifElement.style.setProperty(pausedContentVar, `url(${await createPausedUrl(gifElement.currentSrc)})`);
-  addLabel(gifElement);
+  gifElement.parentElement?.removeAttribute(hasLoadingContentImageAttribute);
 };
 
 const processContentGifs = function (gifElements) {
@@ -264,5 +273,6 @@ export const clean = async function () {
     .forEach(element => element.style.removeProperty(pausedContentVar));
   [...document.querySelectorAll(`img[style*="${pausedBackgroundImageVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedBackgroundImageVar));
+  $(`[${hasLoadingContentImageAttribute}]`).removeAttr(hasLoadingContentImageAttribute);
   $(`[${loadingBackgroundImageAttribute}]`).removeAttr(loadingBackgroundImageAttribute);
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -45,6 +45,11 @@ export const styleElement = buildStyle(`
   font-size: 0.6rem;
 }
 
+${keyToCss('blogCard')} ${keyToCss('headerImage')} .${labelClass} {
+  font-size: 0.8rem;
+  top: calc(140px - 1em - 2.2ch);
+}
+
 .${canvasClass} {
   position: absolute;
   visibility: visible;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -2,11 +2,15 @@ import { pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
+import { getPreferences } from '../../utils/preferences.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
+const posterAttribute = 'data-paused-gif-placeholder';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
+
+let loadingMode;
 
 const hovered = `:is(:hover > *, .${containerClass}:hover *)`;
 
@@ -42,8 +46,14 @@ export const styleElement = buildStyle(`
 
 .${canvasClass}${hovered},
 .${labelClass}${hovered},
-img:has(~ .${canvasClass}):not(${hovered}) {
+img:has(~ .${canvasClass}):not(${hovered}),
+img:has(~ [${posterAttribute}]):not(${hovered}),
+${keyToCss('loader')}:has(~ .${labelClass}):not(${hovered}) {
   display: none;
+}
+
+[${posterAttribute}]:not(${hovered}) {
+  visibility: visible !important;
 }
 
 .${backgroundGifClass}:not(:hover) {
@@ -67,7 +77,15 @@ const addLabel = (element, inside = false) => {
   }
 };
 
+const pauseGifWithPoster = async function (gifElement, posterElement) {
+  addLabel(gifElement);
+  gifElement.decoding = 'sync';
+  loadingMode === 'immediate' && await loaded(gifElement);
+  posterElement.setAttribute(posterAttribute, '');
+};
+
 const pauseGif = async function (gifElement) {
+  await loaded(gifElement);
   gifElement.decode();
 
   const image = new Image();
@@ -86,23 +104,26 @@ const pauseGif = async function (gifElement) {
   };
 };
 
+const loaded = gifElement =>
+  (gifElement.complete && gifElement.currentSrc) ||
+  new Promise(resolve => gifElement.addEventListener('load', resolve, { once: true }));
+
 const processGifs = function (gifElements) {
-  gifElements.forEach(gifElement => {
+  gifElements.forEach(async gifElement => {
     if (gifElement.closest('.block-editor-writing-flow')) return;
     const pausedGifElements = [
       ...gifElement.parentNode.querySelectorAll(`.${canvasClass}`),
       ...gifElement.parentNode.querySelectorAll(`.${labelClass}`)
     ];
     if (pausedGifElements.length) {
-      gifElement.after(...pausedGifElements);
+      gifElement.parentNode.append(...pausedGifElements);
       return;
     }
 
-    if (gifElement.complete && gifElement.currentSrc) {
-      pauseGif(gifElement);
-    } else {
-      gifElement.onload = () => pauseGif(gifElement);
-    }
+    const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
+    posterElement?.currentSrc
+      ? pauseGifWithPoster(gifElement, posterElement)
+      : pauseGif(gifElement);
   });
 };
 
@@ -129,7 +150,18 @@ const processRows = function (rowsElements) {
   });
 };
 
+const onStorageChanged = async function (changes, areaName) {
+  if (areaName !== 'local') return;
+
+  const { 'accesskit.preferences.disable_gifs_loading_mode': modeChanges } = changes;
+  if (modeChanges?.oldValue === undefined) return;
+
+  loadingMode = modeChanges.newValue;
+};
+
 export const main = async function () {
+  ({ disable_gifs_loading_mode: loadingMode } = await getPreferences('accesskit'));
+
   const gifImage = `
     :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]:not(${keyToCss('poster')})
   `;
@@ -144,9 +176,13 @@ export const main = async function () {
     `:is(${postSelector}, ${keyToCss('blockEditorContainer')}) ${keyToCss('rows')}`,
     processRows
   );
+
+  browser.storage.onChanged.addListener(onStorageChanged);
 };
 
 export const clean = async function () {
+  browser.storage.onChanged.removeListener(onStorageChanged);
+
   pageModifications.unregister(processGifs);
   pageModifications.unregister(processBackgroundGifs);
   pageModifications.unregister(processRows);

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -8,6 +8,8 @@ const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
 
+const hovered = `:is(:hover > *, .${containerClass}:hover *)`;
+
 export const styleElement = buildStyle(`
 .${labelClass} {
   position: absolute;
@@ -36,14 +38,11 @@ export const styleElement = buildStyle(`
 .${canvasClass} {
   position: absolute;
   visibility: visible;
-
-  background-color: rgb(var(--white));
 }
 
-*:hover > .${canvasClass},
-*:hover > .${labelClass},
-.${containerClass}:hover .${canvasClass},
-.${containerClass}:hover .${labelClass} {
+.${canvasClass}${hovered},
+.${labelClass}${hovered},
+img:has(~ .${canvasClass}):not(${hovered}) {
   display: none;
 }
 
@@ -68,7 +67,9 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const pauseGif = function (gifElement) {
+const pauseGif = async function (gifElement) {
+  gifElement.decode();
+
   const image = new Image();
   image.src = gifElement.currentSrc;
   image.onload = () => {
@@ -80,7 +81,7 @@ const pauseGif = function (gifElement) {
       canvas.classList.add(canvasClass);
       canvas.getContext('2d').drawImage(image, 0, 0);
       gifElement.parentNode.append(canvas);
-      addLabel(gifElement);
+      addLabel(canvas);
     }
   };
 };

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -1,0 +1,19 @@
+export const memoize = (func) => {
+  const cache = new Map();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg);
+  };
+};
+
+export const weakMemoize = (func) => {
+  const cache = new WeakMap();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg);
+  };
+};


### PR DESCRIPTION
This demos all technologies currently proposed for improving Disable GIFs, in one branch. There are four code paths here:

- Image elements in posts with posters are paused by showing the poster, and also respect a new preference to delay GIF downloads until they're hovered.
- Image elements in posts without posters (i.e. animated webp images), and a few misc image elements, are paused by inserting a canvas element. (This one is a performance optimization, tbh, and probably isn't worth the code).
- Image elements in locations where it would be impractical to insert a canvas element are paused by overwriting their css `content` value to a blob URL of a paused version of their source image. Also, there's a blur effect while this is computed.
- Elements with `background-image` set to a GIF are paused by overwriting their css `background-image` value to a version with the URL replaced with a blob URL of a paused version of their source image. Also, there's a blur effect while this is computed.

Webp images should be paused only if animated.

This is definitely missing at least some commit diffs, like [AprilSylph/XKit-Rewritten@`76e364e` (#1706)](https://github.com/AprilSylph/XKit-Rewritten/pull/1706/commits/76e364e422df2121bf891093849d674a450dc4e9) and [AprilSylph/XKit-Rewritten@`67ff45f` (#1463)](https://github.com/AprilSylph/XKit-Rewritten/pull/1463/commits/67ff45ff166529c17199d3bb518f5ba78be67768), the blur effect isn't applied in code path 2, ~~and gif labels are z-indexed while I figure out a correct way to prevent them from being sometimes covered by the posters in code path 1.~~