### PR TITLE
 Merged AccessKit Disable GIFs dev branch (3)

### DIFF
--- a/src/features/accesskit.json
+++ b/src/features/accesskit.json
@@ -14,6 +14,15 @@
       "label": "Pause GIFs until they are hovered over",
       "default": false
     },
+    "disable_gifs_loading_mode": {
+      "type": "select",
+      "label": "Download paused GIFs:",
+      "options": [
+        { "value": "immediate", "label": "immediately" },
+        { "value": "delayed", "label": "when hovered" }
+      ],
+      "default": "immediate"
+    },
     "boring_tag_chiclets": {
       "type": "checkbox",
       "label": "De-animate the Changes/Shop/etc. links carousel",

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -2,11 +2,15 @@ import { pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
+import { getPreferences } from '../../utils/preferences.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
+const posterAttribute = 'data-paused-gif-placeholder';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
+
+let loadingMode;
 
 const hovered = `:is(:hover > *, .${containerClass}:hover *)`;
 
@@ -42,8 +46,14 @@ export const styleElement = buildStyle(`
 
 .${canvasClass}${hovered},
 .${labelClass}${hovered},
-img:has(~ .${canvasClass}):not(${hovered}) {
+img:has(~ .${canvasClass}):not(${hovered}),
+img:has(~ [${posterAttribute}]):not(${hovered}),
+${keyToCss('loader')}:has(~ .${labelClass}):not(${hovered}) {
   display: none;
+}
+
+[${posterAttribute}]:not(${hovered}) {
+  visibility: visible !important;
 }
 
 .${backgroundGifClass}:not(:hover) {
@@ -67,7 +77,15 @@ const addLabel = (element, inside = false) => {
   }
 };
 
+const pauseGifWithPoster = async function (gifElement, posterElement) {
+  addLabel(gifElement);
+  gifElement.decoding = 'sync';
+  loadingMode === 'immediate' && await loaded(gifElement);
+  posterElement.setAttribute(posterAttribute, '');
+};
+
 const pauseGif = async function (gifElement) {
+  await loaded(gifElement);
   gifElement.decode();
 
   const image = new Image();
@@ -86,23 +104,26 @@ const pauseGif = async function (gifElement) {
   };
 };
 
+const loaded = gifElement =>
+  (gifElement.complete && gifElement.currentSrc) ||
+  new Promise(resolve => gifElement.addEventListener('load', resolve, { once: true }));
+
 const processGifs = function (gifElements) {
-  gifElements.forEach(gifElement => {
+  gifElements.forEach(async gifElement => {
     if (gifElement.closest('.block-editor-writing-flow')) return;
     const pausedGifElements = [
       ...gifElement.parentNode.querySelectorAll(`.${canvasClass}`),
       ...gifElement.parentNode.querySelectorAll(`.${labelClass}`)
     ];
     if (pausedGifElements.length) {
-      gifElement.after(...pausedGifElements);
+      gifElement.parentNode.append(...pausedGifElements);
       return;
     }
 
-    if (gifElement.complete && gifElement.currentSrc) {
-      pauseGif(gifElement);
-    } else {
-      gifElement.onload = () => pauseGif(gifElement);
-    }
+    const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
+    posterElement?.currentSrc
+      ? pauseGifWithPoster(gifElement, posterElement)
+      : pauseGif(gifElement);
   });
 };
 
@@ -129,7 +150,18 @@ const processRows = function (rowsElements) {
   });
 };
 
+const onStorageChanged = async function (changes, areaName) {
+  if (areaName !== 'local') return;
+
+  const { 'accesskit.preferences.disable_gifs_loading_mode': modeChanges } = changes;
+  if (modeChanges?.oldValue === undefined) return;
+
+  loadingMode = modeChanges.newValue;
+};
+
 export const main = async function () {
+  ({ disable_gifs_loading_mode: loadingMode } = await getPreferences('accesskit'));
+
   const gifImage = `
     :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]:not(${keyToCss('poster')})
   `;
@@ -144,9 +176,13 @@ export const main = async function () {
     `:is(${postSelector}, ${keyToCss('blockEditorContainer')}) ${keyToCss('rows')}`,
     processRows
   );
+
+  browser.storage.onChanged.addListener(onStorageChanged);
 };
 
 export const clean = async function () {
+  browser.storage.onChanged.removeListener(onStorageChanged);
+
   pageModifications.unregister(processGifs);
   pageModifications.unregister(processBackgroundGifs);
   pageModifications.unregister(processRows);

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -5,7 +5,6 @@ import { buildStyle, postSelector } from '../../utils/interface.js';
 import { getPreferences } from '../../utils/preferences.js';
 import { memoize } from '../../utils/memoize.js';
 
-const canvasClass = 'xkit-paused-gif-placeholder';
 const posterAttribute = 'data-paused-gif-placeholder';
 const pausedContentVar = '--xkit-paused-gif-content';
 const labelClass = 'xkit-paused-gif-label';
@@ -44,14 +43,7 @@ export const styleElement = buildStyle(`
   font-size: 0.6rem;
 }
 
-.${canvasClass} {
-  position: absolute;
-  visibility: visible;
-}
-
-.${canvasClass}${hovered},
 .${labelClass}${hovered},
-img:has(~ .${canvasClass}):not(${hovered}),
 img:has(~ [${posterAttribute}]):not(${hovered}),
 ${keyToCss('loader')}:has(~ .${labelClass}):not(${hovered}) {
   display: none;
@@ -122,65 +114,30 @@ const pauseGifWithPoster = async function (gifElement, posterElement) {
   posterElement.setAttribute(posterAttribute, '');
 };
 
-const pauseGif = async function (gifElement) {
-  await loaded(gifElement);
-  if (!await isAnimated(gifElement.currentSrc)) return;
-  gifElement.decode();
-
-  const image = new Image();
-  image.src = gifElement.currentSrc;
-  image.onload = () => {
-    if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
-      const canvas = document.createElement('canvas');
-      canvas.width = image.naturalWidth;
-      canvas.height = image.naturalHeight;
-      canvas.className = gifElement.className;
-      canvas.classList.add(canvasClass);
-      canvas.getContext('2d').drawImage(image, 0, 0);
-      gifElement.parentNode.append(canvas);
-      addLabel(canvas);
-    }
-  };
-};
-
 const loaded = gifElement =>
   (gifElement.complete && gifElement.currentSrc) ||
   new Promise(resolve => gifElement.addEventListener('load', resolve, { once: true }));
 
-const processGifs = function (gifElements) {
-  gifElements.forEach(async gifElement => {
-    if (gifElement.closest('.block-editor-writing-flow')) return;
-    const pausedGifElements = [
-      ...gifElement.parentNode.querySelectorAll(`.${canvasClass}`),
-      ...gifElement.parentNode.querySelectorAll(`.${labelClass}`)
-    ];
-    if (pausedGifElements.length) {
-      gifElement.parentNode.append(...pausedGifElements);
-      return;
-    }
-
-    const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
-    posterElement?.currentSrc
-      ? pauseGifWithPoster(gifElement, posterElement)
-      : pauseGif(gifElement);
-  });
-};
-
-const pauseContentGif = async function (gifElement) {
-  await loaded(gifElement);
-  gifElement.style.setProperty(pausedContentVar, `url(${await createPausedUrl(gifElement.currentSrc)})`);
+const pauseGif = async function (gifElement) {
   addLabel(gifElement);
+  await loaded(gifElement);
+  if (await isAnimated(gifElement.currentSrc)) {
+    gifElement.style.setProperty(pausedContentVar, `url(${await createPausedUrl(gifElement.currentSrc)})`);
+  }
 };
 
-const processContentGifs = function (gifElements) {
+const processGifs = function (gifElements) {
   gifElements.forEach(gifElement => {
     if (gifElement.closest('.block-editor-writing-flow')) return;
     const existingLabelElements = gifElement.parentNode.querySelectorAll(`.${labelClass}`);
     if (existingLabelElements.length) {
-      gifElement.after(...existingLabelElements);
+      gifElement.parentNode.append(...existingLabelElements);
       return;
     }
-    pauseContentGif(gifElement);
+    const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
+    posterElement?.currentSrc
+      ? pauseGifWithPoster(gifElement, posterElement)
+      : pauseGif(gifElement);
   });
 };
 
@@ -252,13 +209,9 @@ export const main = async function () {
   enabledTimestamp = Date.now();
 
   const gifImage = `
-    :is(figure, ${keyToCss('tagImage', 'takeoverBanner', 'videoHubsFeatured')}) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
+    :is(figure, main.labs, ${keyToCss('tagImage', 'takeoverBanner', 'videoHubsFeatured', 'headerBanner', 'headerImage', 'typeaheadRow', 'linkCard')}) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
-  const gifContentImage = `
-    :is(main.labs, ${keyToCss('headerBanner', 'headerImage', 'typeaheadRow', 'linkCard')}) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})
-  `;
-  pageModifications.register(gifContentImage, processContentGifs);
 
   const gifBackgroundImage = `
     ${keyToCss('communityHeaderImage', 'communityCategoryImage', 'bannerImage', 'videoHubCardWrapper')}[style*=".gif"]
@@ -284,7 +237,7 @@ export const clean = async function () {
     wrapper.replaceWith(...wrapper.children)
   );
 
-  $(`.${canvasClass}, .${labelClass}`).remove();
+  $(`.${labelClass}`).remove();
   [...document.querySelectorAll(`img[style*="${pausedContentVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedContentVar));
   [...document.querySelectorAll(`img[style*="${pausedBackgroundImageVar}"]`)]

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -8,6 +8,8 @@ const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
 
+const hovered = `:is(:hover > *, .${containerClass}:hover *)`;
+
 export const styleElement = buildStyle(`
 .${labelClass} {
   position: absolute;
@@ -36,14 +38,11 @@ export const styleElement = buildStyle(`
 .${canvasClass} {
   position: absolute;
   visibility: visible;
-
-  background-color: rgb(var(--white));
 }
 
-*:hover > .${canvasClass},
-*:hover > .${labelClass},
-.${containerClass}:hover .${canvasClass},
-.${containerClass}:hover .${labelClass} {
+.${canvasClass}${hovered},
+.${labelClass}${hovered},
+img:has(~ .${canvasClass}):not(${hovered}) {
   display: none;
 }
 
@@ -68,7 +67,9 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const pauseGif = function (gifElement) {
+const pauseGif = async function (gifElement) {
+  gifElement.decode();
+
   const image = new Image();
   image.src = gifElement.currentSrc;
   image.onload = () => {
@@ -80,7 +81,7 @@ const pauseGif = function (gifElement) {
       canvas.classList.add(canvasClass);
       canvas.getContext('2d').drawImage(image, 0, 0);
       gifElement.parentNode.append(canvas);
-      addLabel(gifElement);
+      addLabel(canvas);
     }
   };
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -43,6 +43,11 @@ export const styleElement = buildStyle(`
   font-size: 0.6rem;
 }
 
+${keyToCss('blogCard')} ${keyToCss('headerImage')} .${labelClass} {
+  font-size: 0.8rem;
+  top: calc(140px - 1em - 2.2ch);
+}
+
 .${labelClass}${hovered},
 img:has(~ [${posterAttribute}]):not(${hovered}),
 ${keyToCss('loader')}:has(~ .${labelClass}):not(${hovered}) {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -3,6 +3,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
 import { getPreferences } from '../../utils/preferences.js';
+import { memoize } from '../../utils/memoize.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
 const posterAttribute = 'data-paused-gif-placeholder';
@@ -80,6 +81,29 @@ img[style*="${pausedContentVar}"]:not(${hovered}) {
 }
 `);
 
+const isAnimatedDefault = true;
+const isAnimated = memoize(async (sourceUrl) => {
+  // treat all GIFs like they're animated
+  if (sourceUrl.includes('.gif')) return true;
+
+  if (typeof ImageDecoder !== 'function') return isAnimatedDefault;
+  /* globals ImageDecoder */
+
+  const response = await fetch(sourceUrl);
+
+  const contentType = response.headers.get('Content-Type');
+  const supported = await ImageDecoder.isTypeSupported(contentType);
+  if (!supported) return isAnimatedDefault;
+
+  const decoder = new ImageDecoder({
+    type: contentType,
+    data: response.body,
+    preferAnimation: true
+  });
+  await decoder.tracks.ready;
+  return decoder.tracks.selectedTrack.animated;
+});
+
 const addLabel = (element, inside = false) => {
   if (element.parentNode.querySelector(`.${labelClass}`) === null) {
     const gifLabel = document.createElement('p');
@@ -100,6 +124,7 @@ const pauseGifWithPoster = async function (gifElement, posterElement) {
 
 const pauseGif = async function (gifElement) {
   await loaded(gifElement);
+  if (!await isAnimated(gifElement.currentSrc)) return;
   gifElement.decode();
 
   const image = new Image();
@@ -227,7 +252,7 @@ export const main = async function () {
   enabledTimestamp = Date.now();
 
   const gifImage = `
-    :is(figure, ${keyToCss('tagImage', 'takeoverBanner', 'videoHubsFeatured')}) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})
+    :is(figure, ${keyToCss('tagImage', 'takeoverBanner', 'videoHubsFeatured')}) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
   const gifContentImage = `

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -1,0 +1,19 @@
+export const memoize = (func) => {
+  const cache = new Map();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg);
+  };
+};
+
+export const weakMemoize = (func) => {
+  const cache = new WeakMap();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg);
+  };
+};


### PR DESCRIPTION
This demos all technologies currently proposed for improving Disable GIFs, in one branch. There are three code paths here:

- Image elements with posters are paused by showing the poster, and also respect a new preference to delay GIF downloads until they're hovered.
- ~~Image elements in posts without posters (i.e. animated webp images), and a few misc image elements, are paused by inserting a canvas element. (This one is a performance optimization, tbh, and probably isn't worth the code).~~
- Image elements without posters are paused by overwriting their css `content` value to a blob URL of a paused version of their source image.
- Elements with `background-image` set to a GIF are paused by overwriting their css `background-image` value to a version with the URL replaced with a blob URL of a paused version of their source image. Also, there's a blur effect while this is computed.

Webp images should be paused only if animated.

This is definitely missing at least some commit diffs, like [AprilSylph/XKit-Rewritten@`76e364e` (#1706)](https://github.com/AprilSylph/XKit-Rewritten/pull/1706/commits/76e364e422df2121bf891093849d674a450dc4e9) and [AprilSylph/XKit-Rewritten@`67ff45f` (#1463)](https://github.com/AprilSylph/XKit-Rewritten/pull/1463/commits/67ff45ff166529c17199d3bb518f5ba78be67768).