### PR TITLE
New Feature: Actually working "latest" search. Screw it.

### DIFF
--- a/src/features/index.json
+++ b/src/features/index.json
@@ -6,6 +6,7 @@
   "cleanfeed",
   "collapsed_queue",
   "hide_avatars",
+  "latest_search_plus",
   "limit_checker",
   "mass_deleter",
   "mass_privater",

--- a/src/features/latest_search_plus/feature.json
+++ b/src/features/latest_search_plus/feature.json
@@ -1,0 +1,10 @@
+{
+  "title": "Latest Search+",
+  "description": "Simulate working \"latest\" search",
+  "note": "This feature reorders \"top\" search into chronological order. Endless scrolling must be enabled.",
+  "icon": {
+    "class_name": "ri-search-line",
+    "color": "white",
+    "background_color": "#000000"
+  }
+}

--- a/src/features/latest_search_plus/index.js
+++ b/src/features/latest_search_plus/index.js
@@ -49,7 +49,7 @@ const performSearch = async duration => {
   const postElements = [...scrollContainer.querySelectorAll('[data-cell-id*="post-"]')];
   const arr = postElements.map(el => el.dataset.cellId.replace(/.*post-/, '')).toSorted();
   postElements.forEach(el => {
-    el.style.order = 0 - arr.indexOf(el.dataset.cellId.replace(/.*post-/, ''));
+    el.style.order = -1 - arr.indexOf(el.dataset.cellId.replace(/.*post-/, ''));
   });
 
   window.scrollTo({ top: 0 });

--- a/src/features/latest_search_plus/index.js
+++ b/src/features/latest_search_plus/index.js
@@ -1,0 +1,150 @@
+import { keyToCss } from '../../utils/css_map.js';
+import { dom } from '../../utils/dom.js';
+import { buildStyle, postSelector } from '../../utils/interface.js';
+import { hideModal, showModal } from '../../utils/modals.js';
+import { pageModifications } from '../../utils/mutations.js';
+import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
+import { navigate } from '../../utils/tumblr_helpers.js';
+
+const activeClass = 'xkit-latest-search-plus-active';
+
+export const styleElement = buildStyle(`
+.${activeClass} {
+  display: flex;
+  flex-direction: column;
+}
+
+.${activeClass} > div {
+  position: unset !important;
+}
+`);
+
+const performSearch = async duration => {
+  const searchTermEncoded = location.pathname.split('/')[2];
+  const searchTerm = decodeURIComponent(searchTermEncoded);
+
+  if (
+    location.pathname === `/search/${searchTermEncoded}` &&
+    new URLSearchParams(location.search).get('t') === String(duration)
+  ) {
+    return;
+  }
+
+  navigate(`/search/${searchTermEncoded}?t=${duration}`);
+
+  const scrollContainerSelector = `[data-timeline-id^="searchTimeline-post-${searchTerm}-top-${duration}-"] ${keyToCss('scrollContainer')}`;
+  await new Promise((resolve, reject) => {
+    pageModifications.register(
+      `${scrollContainerSelector} ${postSelector}`,
+      resolve
+    );
+    setTimeout(() => reject(new Error('could not find timeline scroll container!')), 2000);
+  });
+
+  await scrollToBottomOnce();
+
+  const scrollContainer = document.querySelector(scrollContainerSelector);
+  scrollContainer.classList.add(activeClass);
+
+  const postElements = [...scrollContainer.querySelectorAll('[data-cell-id*="post-"]')];
+  const arr = postElements.map(el => el.dataset.cellId.replace(/.*post-/, '')).toSorted();
+  postElements.forEach(el => {
+    el.style.order = 0 - arr.indexOf(el.dataset.cellId.replace(/.*post-/, ''));
+  });
+
+  window.scrollTo({ top: 0 });
+};
+
+const scrollToBottomOnce = () => new Promise(resolve => {
+  const loaderSelector = `
+  ${keyToCss('timeline', 'blogRows')} > :is(${keyToCss('scrollContainer')}, .sortableContainer) + div,
+  ${keyToCss('notifications')} + div
+  `;
+  const knightRiderLoaderSelector = `:is(${loaderSelector}) > ${keyToCss('knightRiderLoader')}`;
+
+  let timeoutID;
+
+  const scrollToBottom = () => {
+    clearTimeout(timeoutID);
+    window.scrollTo({ top: document.documentElement.scrollHeight });
+
+    timeoutID = setTimeout(() => {
+      if (!document.querySelector(knightRiderLoaderSelector)) {
+        stopScrolling();
+        resolve();
+      }
+    }, 500);
+  };
+  const observer = new ResizeObserver(scrollToBottom);
+
+  const startScrolling = () => {
+    observer.observe(document.documentElement);
+    scrollToBottom();
+  };
+
+  const stopScrolling = () => {
+    clearTimeout(timeoutID);
+    observer.disconnect();
+    hideModal();
+  };
+
+  showModal({
+    title: 'Loading "top" posts...',
+    message: ['Please wait!'],
+    buttons: [
+      dom(
+        'button',
+        { class: 'red' },
+        { click: stopScrolling },
+        ['Cancel!']
+      )
+    ]
+  });
+  startScrolling();
+});
+
+const sidebarOptions = {
+  id: 'latest-search-plus',
+  title: 'Latest Search Plus',
+  rows: [
+    {
+      label: 'Show last day',
+      onclick: () => performSearch(1),
+      carrot: true
+    },
+    {
+      label: 'Show last three days',
+      onclick: () => performSearch(3),
+      carrot: true
+    },
+    {
+      label: 'Show last week',
+      onclick: () => performSearch(7),
+      carrot: true
+    },
+    {
+      label: 'Show last month',
+      onclick: () => performSearch(30),
+      carrot: true
+    }
+  ],
+  visibility: () => /^\/search\/[^/]+/.test(location.pathname)
+};
+
+const stopBuggyScroll = event => {
+  if (['KeyJ', 'KeyK'].includes(event.code) && document.querySelector(`.${activeClass}`)) {
+    event.stopPropagation();
+  }
+};
+
+export const main = async function () {
+  addSidebarItem(sidebarOptions);
+  document.body.addEventListener('keydown', stopBuggyScroll);
+};
+
+export const clean = async function () {
+  removeSidebarItem(sidebarOptions.id);
+  document.body.removeEventListener('keydown', stopBuggyScroll);
+
+  $(`.${activeClass}`).removeClass(activeClass);
+};

--- a/src/features/latest_search_plus/index.js
+++ b/src/features/latest_search_plus/index.js
@@ -6,16 +6,32 @@ import { pageModifications } from '../../utils/mutations.js';
 import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { navigate } from '../../utils/tumblr_helpers.js';
 
-const activeClass = 'xkit-latest-search-plus-active';
+const activeAttr = 'data-latest-search-plus';
 
 export const styleElement = buildStyle(`
-.${activeClass} {
+[${activeAttr}] {
   display: flex;
   flex-direction: column;
 }
 
-.${activeClass} > div {
+[${activeAttr}] > div {
   position: unset !important;
+}
+
+[${activeAttr}]::before {
+  order: ${Number.MIN_SAFE_INTEGER};
+  border-radius: 8px;
+  padding: 20px;
+  margin-bottom: 20px;
+
+  content: 'Latest ' attr(${activeAttr}) ' days of posts in chronological order:';
+  background-color: var(--chrome-panel);
+  color: var(--chrome-fg);
+  font-size: 1.125rem;
+}
+
+[${activeAttr}="1"]::before {
+  content: 'Latest ' attr(${activeAttr}) ' day of posts in chronological order:';
 }
 `);
 
@@ -44,7 +60,7 @@ const performSearch = async duration => {
   await scrollToBottomOnce();
 
   const scrollContainer = document.querySelector(scrollContainerSelector);
-  scrollContainer.classList.add(activeClass);
+  scrollContainer.setAttribute(activeAttr, duration);
 
   const postElements = [...scrollContainer.querySelectorAll('[data-cell-id*="post-"]')];
   const arr = postElements.map(el => el.dataset.cellId.replace(/.*post-/, '')).toSorted();
@@ -132,7 +148,7 @@ const sidebarOptions = {
 };
 
 const stopBuggyScroll = event => {
-  if (['KeyJ', 'KeyK'].includes(event.code) && document.querySelector(`.${activeClass}`)) {
+  if (['KeyJ', 'KeyK'].includes(event.code) && document.querySelector(`[${activeAttr}]`)) {
     event.stopPropagation();
   }
 };
@@ -146,5 +162,5 @@ export const clean = async function () {
   removeSidebarItem(sidebarOptions.id);
   document.body.removeEventListener('keydown', stopBuggyScroll);
 
-  $(`.${activeClass}`).removeClass(activeClass);
+  $(`[${activeAttr}]`).removeAttr(activeAttr);
 };

--- a/src/features/latest_search_plus/index.js
+++ b/src/features/latest_search_plus/index.js
@@ -12,6 +12,7 @@ export const styleElement = buildStyle(`
 [${activeAttr}] {
   display: flex;
   flex-direction: column;
+  height: unset !important;
 }
 
 [${activeAttr}] > div {
@@ -82,7 +83,7 @@ const scrollToBottomOnce = () => new Promise(resolve => {
 
   const scrollToBottom = () => {
     clearTimeout(timeoutID);
-    window.scrollTo({ top: document.documentElement.scrollHeight });
+    window.scrollTo({ top: document.documentElement.scrollHeight, behavior: 'smooth' });
 
     timeoutID = setTimeout(() => {
       if (!document.querySelector(knightRiderLoaderSelector)) {

--- a/src/features/latest_search_plus/index.js
+++ b/src/features/latest_search_plus/index.js
@@ -1,6 +1,6 @@
 import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
-import { buildStyle, postSelector } from '../../utils/interface.js';
+import { blogViewSelector, buildStyle, postSelector } from '../../utils/interface.js';
 import { hideModal, showModal } from '../../utils/modals.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
@@ -149,7 +149,7 @@ const sidebarOptions = {
 };
 
 const stopBuggyScroll = event => {
-  if (['KeyJ', 'KeyK'].includes(event.code) && document.querySelector(`[${activeAttr}]`)) {
+  if (['KeyJ', 'KeyK'].includes(event.code) && document.querySelector(`[${activeAttr}]`) && document.querySelector(blogViewSelector) === null) {
     event.stopPropagation();
   }
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds a hacky feature to simulate "latest" search working as well as "top." Specifically, this adds a sidebar button that loads "top" search for the current search keyword, scrolls down until every result is onscreen, then sorts them chronologically.

Compare this to the actual "latest" search result page.

<!--
### Testing steps

  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

