### PR TITLE
experiment: More server-efficient/less visually janky Scroll to Bottom?

### DIFF
--- a/src/features/scroll_to_bottom.js
+++ b/src/features/scroll_to_bottom.js
@@ -2,6 +2,7 @@ import { keyToClasses, keyToCss } from '../utils/css_map.js';
 import { translate } from '../utils/language_data.js';
 import { pageModifications } from '../utils/mutations.js';
 import { buildStyle } from '../utils/interface.js';
+import { inject } from '../utils/inject.js';
 
 const scrollToBottomButtonId = 'xkit-scroll-to-bottom-button';
 $(`[id="${scrollToBottomButtonId}"]`).remove();
@@ -23,6 +24,7 @@ export const styleElement = buildStyle(`
 `);
 
 let timeoutID;
+let loadCounter = 0;
 
 const onLoadersAdded = loaders => {
   if (active) {
@@ -32,11 +34,21 @@ const onLoadersAdded = loaders => {
 
 const scrollToBottom = () => {
   clearTimeout(timeoutID);
-  window.scrollTo({ top: document.documentElement.scrollHeight });
+
+  const loader = document.querySelector(loaderSelector);
+  if (loader) {
+    inject('/main_world/trigger_scroll.js', [], loader);
+    if (loadCounter++ % 10 === 0) {
+      window.scrollBy({ top: loader.getBoundingClientRect().top - window.innerHeight });
+    }
+  } else {
+    window.scrollTo({ top: document.documentElement.scrollHeight });
+  }
 
   timeoutID = setTimeout(() => {
     if (!document.querySelector(knightRiderLoaderSelector)) {
       stopScrolling();
+      window.scrollTo({ top: document.documentElement.scrollHeight });
     }
   }, 500);
 };
@@ -45,6 +57,7 @@ const observer = new ResizeObserver(scrollToBottom);
 const startScrolling = () => {
   observer.observe(document.documentElement);
   active = true;
+  loadCounter = 0;
   scrollToBottomButton.classList.add(activeClass);
   scrollToBottom();
 };

--- a/src/main_world/trigger_scroll.js
+++ b/src/main_world/trigger_scroll.js
@@ -1,0 +1,15 @@
+export default function triggerScroll () {
+  const element = this;
+  const reactKey = Object.keys(element).find(key => key.startsWith('__reactFiber'));
+  let fiber = element[reactKey];
+
+  while (fiber !== null) {
+    const { hasNextPage, fetchNext } = fiber.memoizedProps || {};
+    if (hasNextPage && fetchNext) {
+      fetchNext(true);
+      return;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This currently doesn't work because while the "fetch only the post JSON from the API; don't download media" code works great, it results in all of the fetched posts being rendered with zero height in a bunch at the end of the timeline, and when one does scroll down into this, they all get rendered.

Probably not fixable unless the virtual scroller code gets changed.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

