### PR TITLE
Temporarily deprecate Panorama; custom deprecation reason

### DIFF
--- a/docs/Chapter 4.1 - Feature manifests.md
+++ b/docs/Chapter 4.1 - Feature manifests.md
@@ -109,3 +109,9 @@ The storage key to inherit the value of, if the preference has not been set.
 - Required: No
 
 Whether to hide the feature on installations on which it was not enabled at the time of deprecation.
+
+### `"deprecationReason"`
+- Type: String
+- Required: No
+
+String to show in the configuration panel if the script is deprecated but enabled (default: "deprecated")

--- a/docs/Chapter 4.1 - Feature manifests.md
+++ b/docs/Chapter 4.1 - Feature manifests.md
@@ -104,8 +104,8 @@ If the preference `type` is `"select"`, this value should be a string that match
 
 The storage key to inherit the value of, if the preference has not been set.
 
-### `"deprecationReason"`
-- Type: String
+### `"deprecated"`
+- Type: Boolean
 - Required: No
 
-If set, the feature will be hidden on installations on which it was not enabled at the time of deprecation. 
+Whether to hide the feature on installations on which it was not enabled at the time of deprecation.

--- a/docs/Chapter 4.1 - Feature manifests.md
+++ b/docs/Chapter 4.1 - Feature manifests.md
@@ -104,8 +104,8 @@ If the preference `type` is `"select"`, this value should be a string that match
 
 The storage key to inherit the value of, if the preference has not been set.
 
-### `"deprecated"`
-- Type: Boolean
+### `"deprecationReason"`
+- Type: String
 - Required: No
 
-Whether to hide the feature on installations on which it was not enabled at the time of deprecation.
+If set, the feature will be hidden on installations on which it was not enabled at the time of deprecation. 

--- a/src/action/configuration.css
+++ b/src/action/configuration.css
@@ -144,8 +144,8 @@ label[for="filter"] {
   font-weight: normal;
 }
 
-.script:not(.disabled) .title[data-deprecation-reason]::after {
-  content: attr(data-deprecation-reason);
+.script:not(.disabled)[data-deprecated="true"] .title::after {
+  content: "(deprecated)";
   margin-left: 0.5ch;
   font-weight: normal;
 }

--- a/src/action/configuration.css
+++ b/src/action/configuration.css
@@ -145,7 +145,7 @@ label[for="filter"] {
 }
 
 .script:not(.disabled)[data-deprecated="true"] .title::after {
-  content: "(deprecated)";
+  content: attr(data-deprecation-reason);
   margin-left: 0.5ch;
   font-weight: normal;
 }

--- a/src/action/configuration.css
+++ b/src/action/configuration.css
@@ -144,8 +144,8 @@ label[for="filter"] {
   font-weight: normal;
 }
 
-.script:not(.disabled)[data-deprecated="true"] .title::after {
-  content: "(deprecated)";
+.script:not(.disabled) .title[data-deprecation-reason]::after {
+  content: attr(data-deprecation-reason);
   margin-left: 0.5ch;
   font-weight: normal;
 }

--- a/src/action/render_scripts.js
+++ b/src/action/render_scripts.js
@@ -25,7 +25,7 @@ const writeEnabled = async function ({ currentTarget }) {
     enabledScripts = enabledScripts.filter(x => x !== id);
     detailsElement.classList.add('disabled');
 
-    if (detailsElement.dataset.deprecationReason && !specialAccess.includes(id)) {
+    if (detailsElement.dataset.deprecated === 'true' && !specialAccess.includes(id)) {
       specialAccess.push(id);
     }
   }
@@ -145,18 +145,19 @@ const renderScripts = async function () {
       help = '',
       relatedTerms = [],
       preferences = {},
-      deprecationReason
+      deprecated = false
     } = await file.json();
 
     const scriptTemplateClone = document.getElementById('script').content.cloneNode(true);
 
     const detailsElement = scriptTemplateClone.querySelector('details.script');
     detailsElement.dataset.relatedTerms = relatedTerms;
+    detailsElement.dataset.deprecated = deprecated;
 
     if (enabledScripts.includes(scriptName) === false) {
       detailsElement.classList.add('disabled');
 
-      if (deprecationReason && !specialAccess.includes(scriptName)) {
+      if (deprecated && !specialAccess.includes(scriptName)) {
         continue;
       }
     }
@@ -172,11 +173,6 @@ const renderScripts = async function () {
 
     const titleHeading = scriptTemplateClone.querySelector('h4.title');
     titleHeading.textContent = title;
-
-    if (deprecationReason) {
-      detailsElement.dataset.deprecationReason = `(${deprecationReason})`;
-      titleHeading.dataset.deprecationReason = `(${deprecationReason})`;
-    }
 
     if (description !== '') {
       const descriptionParagraph = scriptTemplateClone.querySelector('p.description');

--- a/src/action/render_scripts.js
+++ b/src/action/render_scripts.js
@@ -25,7 +25,7 @@ const writeEnabled = async function ({ currentTarget }) {
     enabledScripts = enabledScripts.filter(x => x !== id);
     detailsElement.classList.add('disabled');
 
-    if (detailsElement.dataset.deprecated === 'true' && !specialAccess.includes(id)) {
+    if (detailsElement.dataset.deprecationReason && !specialAccess.includes(id)) {
       specialAccess.push(id);
     }
   }
@@ -145,19 +145,18 @@ const renderScripts = async function () {
       help = '',
       relatedTerms = [],
       preferences = {},
-      deprecated = false
+      deprecationReason
     } = await file.json();
 
     const scriptTemplateClone = document.getElementById('script').content.cloneNode(true);
 
     const detailsElement = scriptTemplateClone.querySelector('details.script');
     detailsElement.dataset.relatedTerms = relatedTerms;
-    detailsElement.dataset.deprecated = deprecated;
 
     if (enabledScripts.includes(scriptName) === false) {
       detailsElement.classList.add('disabled');
 
-      if (deprecated && !specialAccess.includes(scriptName)) {
+      if (deprecationReason && !specialAccess.includes(scriptName)) {
         continue;
       }
     }
@@ -173,6 +172,11 @@ const renderScripts = async function () {
 
     const titleHeading = scriptTemplateClone.querySelector('h4.title');
     titleHeading.textContent = title;
+
+    if (deprecationReason) {
+      detailsElement.dataset.deprecationReason = `(${deprecationReason})`;
+      titleHeading.dataset.deprecationReason = `(${deprecationReason})`;
+    }
 
     if (description !== '') {
       const descriptionParagraph = scriptTemplateClone.querySelector('p.description');

--- a/src/action/render_scripts.js
+++ b/src/action/render_scripts.js
@@ -145,7 +145,8 @@ const renderScripts = async function () {
       help = '',
       relatedTerms = [],
       preferences = {},
-      deprecated = false
+      deprecated = false,
+      deprecationReason = 'deprecated'
     } = await file.json();
 
     const scriptTemplateClone = document.getElementById('script').content.cloneNode(true);
@@ -173,6 +174,9 @@ const renderScripts = async function () {
 
     const titleHeading = scriptTemplateClone.querySelector('h4.title');
     titleHeading.textContent = title;
+    if (deprecated) {
+      titleHeading.dataset.deprecationReason = `(${deprecationReason})`;
+    }
 
     if (description !== '') {
       const descriptionParagraph = scriptTemplateClone.querySelector('p.description');

--- a/src/features/panorama.json
+++ b/src/features/panorama.json
@@ -7,5 +7,7 @@
     "color": "white",
     "background_color": "#1a2735"
   },
-  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#panorama"
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#panorama",
+  "deprecated": true,
+  "deprecationReason": "outdated"
 }

--- a/src/features/timestamps.json
+++ b/src/features/timestamps.json
@@ -34,5 +34,5 @@
       "default": "op"
     }
   },
-  "deprecated": true
+  "deprecationReason": "deprecated"
 }

--- a/src/features/timestamps.json
+++ b/src/features/timestamps.json
@@ -34,5 +34,5 @@
       "default": "op"
     }
   },
-  "deprecationReason": "deprecated"
+  "deprecated": true
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Random idea I had: deprecation messages shown to users with the deprecated script enabled could be customizable, and this could be used to use the deprecation feature on a temporary basis to hide scripts that we know don't work from new users until their functionality is restored. Also makes #1216 less silly.

Probably would deserve some reworking of the internal term "deprecated," though. `limitedAccess`? Eh.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Panorama doesn't appear on a preference save which hasn't had it enabled before.
- Confirm that Panorama appears as `Panorama (outdated)` in the options UI on a preference save which has had it enabled before.