### PR TITLE
Indicate and disable currently-outdated features

### DIFF
--- a/src/action/configuration.css
+++ b/src/action/configuration.css
@@ -150,6 +150,16 @@ label[for="filter"] {
   font-weight: normal;
 }
 
+.script:not(.disabled)[data-outdated="true"] .title::after {
+  content: "(outdated)";
+  margin-left: 0.5ch;
+  font-weight: normal;
+}
+
+.script[data-outdated="true"] .meta {
+  opacity: 0.6;
+}
+
 .script .note {
   padding: 1ch 2ch;
   margin: 0;

--- a/src/action/render_scripts.js
+++ b/src/action/render_scripts.js
@@ -141,6 +141,7 @@ const renderScripts = async function () {
       title = scriptName,
       description = '',
       note = '',
+      outdated = false,
       icon = {},
       help = '',
       relatedTerms = [],
@@ -153,6 +154,7 @@ const renderScripts = async function () {
     const detailsElement = scriptTemplateClone.querySelector('details.script');
     detailsElement.dataset.relatedTerms = relatedTerms;
     detailsElement.dataset.deprecated = deprecated;
+    detailsElement.dataset.outdated = outdated;
 
     if (enabledScripts.includes(scriptName) === false) {
       detailsElement.classList.add('disabled');

--- a/src/features/panorama.json
+++ b/src/features/panorama.json
@@ -2,6 +2,7 @@
   "title": "Panorama",
   "description": "Widescreen dashboard",
   "note": "This feature is not currently functional.",
+  "outdated": true,
   "icon": {
     "class_name": "ri-align-justify",
     "color": "white",

--- a/src/features/quote_replies.json
+++ b/src/features/quote_replies.json
@@ -6,6 +6,8 @@
     "color": "white",
     "background_color": "#00b8ff"
   },
+  "note": "This feature is not currently functional.",
+  "outdated": true,
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#quote-replies",
   "preferences": {
     "tagReplyingBlog": {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Eh, I mean, it's an idea.

<img width="374" src="https://github.com/user-attachments/assets/e7ee1913-eb3c-477b-869c-d7d563aa16cf">

This implements the ability to mark a feature as outdated and completely nonfunctional in the metadata. Outdated scripts aren't run even if enabled* and are marked visually in the preferences popup. This might make sense for a feature we expect to be outdated (only) in the short term; I feel like it's better than hiding the feature and having people wonder if they imagined it existing this whole time.

Related: #1526, which uses the "deprecation" mechanism to make a outdated feature not appear to new users until it's back to functioning correctly (particularly makes sense for long-term-outdated features). Probably makes sense to implement an overarching strategy addressing both of these things, maybe with a single flag; I haven't fully thought it through.

*currently not true if you toggle them on, or off and on; I guess I'd need to refactor to fix this

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

