### PR TITLE
Tweaks: Organize tweaks

### DIFF
--- a/docs/Chapter 4.1 - Feature manifests.md
+++ b/docs/Chapter 4.1 - Feature manifests.md
@@ -67,11 +67,11 @@ It is recommended to use camelCase for each preference name, so that the script 
 - Type: String
 - Required: Yes
 
-Type of preference. Supported values: `"checkbox"`, `"text"`, `"color"`, `"select"`, `"textarea"`, `"iframe"`
+Type of preference. Supported values: `"checkbox"`, `"text"`, `"color"`, `"select"`, `"textarea"`, `"iframe"`, `"gap"`
 
 #### `"preferences"`: \<preference name\>: `"label"`
 - Type: String
-- Required: Yes
+- Required: Yes, unless `type` is `"gap"`
 
 Label displayed to the user to describe the preference.
 
@@ -89,7 +89,7 @@ For `"iframe"`-type preferences, a relative address to be embedded in the script
 
 #### `"preferences"`: \<preference name\>: `"default"`
 - Type: Any
-- Required: Yes, unless `type` is `"iframe"`
+- Required: Yes, unless `type` is `"iframe"` or `"gap"`
 
 Default value of the preference to display to the user.
 

--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -147,6 +147,10 @@
       </li>
     </template>
 
+    <template id="gap-preference">
+      <li></li>
+    </template>
+
     <script src="/lib/browser-polyfill.min.js"></script>
     <script src="/lib/jquery.min.js"></script>
     <script src="/lib/spectrum.js"></script>

--- a/src/action/render_scripts.js
+++ b/src/action/render_scripts.js
@@ -67,6 +67,11 @@ const renderPreferences = async function ({ scriptName, preferences, preferenceL
 
     const preferenceTemplateClone = document.getElementById(`${preference.type}-preference`).content.cloneNode(true);
 
+    if (preference.type === 'gap') {
+      preferenceList.appendChild(preferenceTemplateClone);
+      continue;
+    }
+
     const preferenceInput = preferenceTemplateClone.querySelector('input, select, textarea, iframe');
     preferenceInput.id = `${scriptName}.${preference.type}.${key}`;
 

--- a/src/features/tweaks.json
+++ b/src/features/tweaks.json
@@ -17,11 +17,6 @@
       "label": "Restore links to individual posts in the post header",
       "default": false
     },
-    "slim_filtered_screens": {
-      "type": "checkbox",
-      "label": "Use a slim layout for filtered posts",
-      "default": false
-    },
     "highlight_contributed_content": {
       "type": "checkbox",
       "label": "Highlight contributed content on reblogs",
@@ -32,14 +27,13 @@
       "label": "Show every line of tags by default",
       "default": false
     },
+
+    "gap_clean_ui": {
+      "type": "gap"
+    },
     "caught_up_line": {
       "type": "checkbox",
       "label": "Turn the Changes/Shop/etc. links carousel into a separating line",
-      "default": false
-    },
-    "no_focus_shadow": {
-      "type": "checkbox",
-      "label": "Remove the coloured shadow from focused posts",
       "default": false
     },
     "unsticky_tab_bar": {
@@ -47,51 +41,24 @@
       "label": "Remove the sticky effect from the dashboard tab bar",
       "default": false
     },
-    "hide_mini_follow": {
+    "no_focus_shadow": {
       "type": "checkbox",
-      "label": "Hide mini-follow buttons on posts",
-      "default": false,
-      "inherit": "tweaks.preferences.subtle_follow"
-    },
-    "subtle_activity_mutuals": {
-      "type": "checkbox",
-      "label": "Make following/mutuals indicators on notifications more subtle",
+      "label": "Remove the coloured shadow from focused posts",
       "default": false
     },
-    "hide_activity_mutuals": {
+    "no_where_were_we": {
       "type": "checkbox",
-      "label": "Hide following/mutuals indicators on notifications",
-      "default": false
-    },
-    "hide_footer_tooltips": {
-      "type": "checkbox",
-      "label": "Hide control button tooltips in the post footer",
-      "default": false
-    },
-    "hide_blaze_tip_labels": {
-      "type": "checkbox",
-      "label": "Hide the \"blaze\" and \"tip\" button labels",
-      "default": false
-    },
-    "hide_filtered_posts": {
-      "type": "checkbox",
-      "label": "Hide filtered posts entirely",
-      "default": false
-    },
-    "hide_my_posts": {
-      "type": "checkbox",
-      "label": "Hide my own posts on the dashboard",
-      "default": false
-    },
-    "hide_liked_posts": {
-      "type": "checkbox",
-      "label": "Hide posts that I've liked on the dashboard",
+      "label": "Hide the \"Now, where were we?\" button",
       "default": false
     },
     "hide_follower_counts": {
       "type": "checkbox",
       "label": "Hide my follower count where possible",
       "default": false
+    },
+
+    "gap_badges": {
+      "type": "gap"
     },
     "hide_following_notification_badge": {
       "type": "checkbox",
@@ -103,9 +70,66 @@
       "label": "Hide the Activity notification badge",
       "default": false
     },
-    "no_where_were_we": {
+
+    "gap_activity": {
+      "type": "gap"
+    },
+    "subtle_activity_mutuals": {
       "type": "checkbox",
-      "label": "Hide the \"Now, where were we?\" button",
+      "label": "Make following/mutuals indicators on notifications more subtle",
+      "default": false
+    },
+    "hide_activity_mutuals": {
+      "type": "checkbox",
+      "label": "Hide following/mutuals indicators on notifications",
+      "default": false
+    },
+
+    "gap_clean_post_ui": {
+      "type": "gap"
+    },
+    "hide_mini_follow": {
+      "type": "checkbox",
+      "label": "Hide mini-follow buttons on posts",
+      "default": false,
+      "inherit": "tweaks.preferences.subtle_follow"
+    },
+    "hide_blaze_tip_labels": {
+      "type": "checkbox",
+      "label": "Hide the \"blaze\" and \"tip\" button labels",
+      "default": false
+    },
+    "hide_footer_tooltips": {
+      "type": "checkbox",
+      "label": "Hide control button tooltips in the post footer",
+      "default": false
+    },
+
+    "gap_filtered": {
+      "type": "gap"
+    },
+    "slim_filtered_screens": {
+      "type": "checkbox",
+      "label": "Use a slim layout for filtered posts",
+      "default": false
+    },
+    "hide_filtered_posts": {
+      "type": "checkbox",
+      "label": "Hide filtered posts entirely",
+      "default": false
+    },
+
+    "gap_hide_posts": {
+      "type": "gap"
+    },
+    "hide_my_posts": {
+      "type": "checkbox",
+      "label": "Hide my own posts on the dashboard",
+      "default": false
+    },
+    "hide_liked_posts": {
+      "type": "checkbox",
+      "label": "Hide posts that I've liked on the dashboard",
       "default": false
     }
   }

--- a/src/features/tweaks.json
+++ b/src/features/tweaks.json
@@ -24,7 +24,7 @@
     },
     "show_all_tags": {
       "type": "checkbox",
-      "label": "Show every line of tags by default",
+      "label": "Show every line of post tags by default",
       "default": false
     },
 
@@ -43,7 +43,7 @@
     },
     "no_focus_shadow": {
       "type": "checkbox",
-      "label": "Remove the coloured shadow from focused posts",
+      "label": "Hide the coloured shadow on focused posts",
       "default": false
     },
     "no_where_were_we": {
@@ -62,7 +62,7 @@
     },
     "hide_following_notification_badge": {
       "type": "checkbox",
-      "label": "Hide the Home/Following unread count",
+      "label": "Hide the Home/Following unread count badge",
       "default": false
     },
     "hide_activity_notification_badge": {
@@ -81,7 +81,7 @@
     },
     "hide_activity_mutuals": {
       "type": "checkbox",
-      "label": "Hide following/mutuals indicators on notifications",
+      "label": "Hide following/mutuals indicators on notifications entirely",
       "default": false
     },
 
@@ -96,7 +96,7 @@
     },
     "hide_blaze_tip_labels": {
       "type": "checkbox",
-      "label": "Hide the \"blaze\" and \"tip\" button labels",
+      "label": "Hide \"blaze\" and \"tip\" button labels in the post footer",
       "default": false
     },
     "hide_footer_tooltips": {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

| before | after |
| - | - |
| <img width="375" src="https://github.com/user-attachments/assets/0bab0097-0d64-49fa-800f-7d0a9fd10309"> | <img width="375"  src="https://github.com/user-attachments/assets/64200ecb-2acb-4b67-88cd-a3a244b1756b"> |

We have a bunch of tweaks that naturally go together due to being variations on each other, affecting similar parts of the UI, etc. It's not that easy to parse visually, and I think a lot of people miss some of the features due to this.

I was thinking about ways to make this a little more clear in a way without noticeably changing how the preference UI looks; this is (the most subtle version of) that. Preferences are grouped a little bit, and some of the names are tweaked to read more consistently within the groups. Thoughts?

(If we want to do something like this, this feels very much like one of those "this PR is yours now; poke it with a stick until you like the resulting UI" ones.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that no tweaks got lost in the shuffle.

Feel free to express an opinion about the grouping, order, and layout of these changes.