### PR TITLE
Use `display: contents` on poster for lazy-loaded gif pausing

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -6,7 +6,8 @@ import { pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
-const pausedPosterAttribute = 'data-paused-gif-use-poster';
+const pausedFigureAttribute = 'data-paused-gif-use-figure';
+const pausedFigureAspectRatioVar = '--xkit-paused-gif-figure-aspect-ratio';
 const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
 const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelAttribute = 'data-paused-gif-label';
@@ -64,7 +65,6 @@ export const styleElement = buildStyle(`
 .${canvasClass}${parentHovered},
 [${labelAttribute}="after"]${hovered}::after,
 [${labelAttribute}="before"]${hovered}::before,
-[${pausedPosterAttribute}]:not(${hovered}) > ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')},
 [${labelAttribute}]:not(${hovered}) > ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')} {
   display: none !important;
 }
@@ -74,14 +74,11 @@ ${keyToCss('background')}[${labelAttribute}="before"]::before {
   display: none;
 }
 
-[${pausedPosterAttribute}]:not(${hovered}) > img${keyToCss('poster')} {
-  visibility: visible !important;
+[${pausedFigureAttribute}]:not(${hovered}) > ${keyToCss('placeholder')} {
+  display: contents;
 }
-[${pausedPosterAttribute}="eager"]:not(${hovered}) > img:not(${keyToCss('poster')}) {
-  visibility: hidden !important;
-}
-[${pausedPosterAttribute}="lazy"]:not(${hovered}) > img:not(${keyToCss('poster')}) {
-  display: none;
+[${pausedFigureAttribute}]:not(${hovered}) {
+  aspect-ratio: var(${pausedFigureAspectRatioVar});
 }
 
 [style*="${pausedBackgroundImageVar}"]:not(${hovered}) {
@@ -198,10 +195,14 @@ const processGifs = function (gifElements) {
 
     gifElement.decoding = 'sync';
 
-    const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
-    if (posterElement) {
-      gifElement.parentElement.setAttribute(pausedPosterAttribute, loadingMode);
-      addLabel(posterElement);
+    if (loadingMode === 'lazy' && gifElement.matches(`figure > ${keyToCss('placeholder')}[style*="padding-bottom"] > *`)) {
+      const placeholderElement = gifElement.parentElement;
+      const figureElement = gifElement.parentElement.parentElement;
+
+      figureElement.setAttribute(pausedFigureAttribute, '');
+      figureElement.style.setProperty(pausedFigureAspectRatioVar, `100 / ${placeholderElement.style.paddingBottom.replace('%', '')}`);
+
+      addLabel(gifElement);
       return;
     }
 
@@ -333,7 +334,7 @@ export const clean = async function () {
   $(`.${canvasClass}`).remove();
   $(`[${labelAttribute}]`).removeAttr(labelAttribute);
   $(`[${labelSizeAttribute}]`).removeAttr(labelSizeAttribute);
-  $(`[${pausedPosterAttribute}]`).removeAttr(pausedPosterAttribute);
+  $(`[${pausedFigureAttribute}]`).removeAttr(pausedFigureAttribute);
   $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
   [...document.querySelectorAll(`[style*="${pausedBackgroundImageVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedBackgroundImageVar));

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -290,6 +290,7 @@ export const main = async function () {
     ) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
+  pageModifications.register(`${gifImage} ~ ${keyToCss('playButton')}`, processNativeGifPlayButtons);
 
   const gifBackgroundImage = `
     ${keyToCss(
@@ -311,8 +312,6 @@ export const main = async function () {
     `:is(${postSelector}, ${keyToCss('blockEditorContainer')}) ${keyToCss('rows')}`,
     processRows,
   );
-
-  pageModifications.register(`${gifImage} ~ ${keyToCss('playButton')}`, processNativeGifPlayButtons);
 
   browser.storage.local.onChanged.addListener(onStorageChanged);
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -64,7 +64,8 @@ export const styleElement = buildStyle(`
 .${canvasClass}${parentHovered},
 [${labelAttribute}="after"]${hovered}::after,
 [${labelAttribute}="before"]${hovered}::before,
-[${pausedPosterAttribute}]:not(${hovered}) > div > ${keyToCss('knightRiderLoader')} {
+[${pausedPosterAttribute}]:not(${hovered}) > ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')},
+[${labelAttribute}]:not(${hovered}) > ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')} {
   display: none !important;
 }
 ${keyToCss('background')}[${labelAttribute}="after"]::after,
@@ -266,6 +267,8 @@ const onStorageChanged = async function (changes) {
   loadingMode = modeChanges.newValue;
 };
 
+const processNativeGifPlayButtons = buttons => buttons.forEach(button => button.click());
+
 export const main = async function () {
   ({ disable_gifs_loading_mode: loadingMode } = await getPreferences('accesskit'));
 
@@ -309,6 +312,8 @@ export const main = async function () {
     processRows,
   );
 
+  pageModifications.register(`${gifImage} ~ ${keyToCss('playButton')}`, processNativeGifPlayButtons);
+
   browser.storage.local.onChanged.addListener(onStorageChanged);
 };
 
@@ -319,6 +324,8 @@ export const clean = async function () {
   pageModifications.unregister(processBackgroundGifs);
   pageModifications.unregister(processRows);
   pageModifications.unregister(processHoverableElements);
+
+  pageModifications.unregister(processNativeGifPlayButtons);
 
   [...document.querySelectorAll(`.${containerClass}`)].forEach(wrapper =>
     wrapper.replaceWith(...wrapper.children),


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

What's the equivalent of the term "bit twiddling" for doing nonobvious things with a piece of minified react code? Frontend twiddling?

This was an experiment to try to reimplement the only-download-on-hover AccessKit Disable GIFs pausing behavior after the removal of the stationary native poster element by taking advantage of the fact that the "placeholder" element loads a poster image instead of an animated one if it thinks it's offscreen. Setting it to `display: contents` makes it have no bounding box, which does this. Unfortunately, we need it for layout (solved—I think—by moving the aspect ratio bounding up to the containing figure), loading indicators (not solved), loading gradients (not solved), and probably some other stuff.

Likely better solution: let the child image be of the animated source, and just `display: none` it. Then, grab the poster source url out of the react props and use that for our pause overlay. 

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

