### PR TITLE
broadcast channel demo

### DIFF
--- a/src/action/popup.js
+++ b/src/action/popup.js
@@ -117,3 +117,10 @@ browser.permissions
 const params = new URLSearchParams(location.search);
 const pageIsEmbedded = params.get('embedded') === 'true';
 document.getElementById('embedded-banner').hidden = !pageIsEmbedded;
+
+const id = Math.random();
+const popupId = `popup ${id}`;
+const channel = new BroadcastChannel('xkit_test');
+channel.addEventListener('message', (event) => {
+  console.log(`${popupId} received message: ${event.data}`);
+});

--- a/src/action/popup.js
+++ b/src/action/popup.js
@@ -122,5 +122,7 @@ const id = Math.random();
 const popupId = `popup ${id}`;
 const channel = new BroadcastChannel('xkit_test');
 channel.addEventListener('message', (event) => {
-  console.log(`${popupId} received message: ${event.data}`);
+  if (event.data.id === id) return;
+  const now = performance.timeOrigin + performance.now();
+  console.log(`${popupId} received message: ${event.data.message}. delay: ${now - event.data.now}`);
 });

--- a/src/main_world/test_broadcast_channel.js
+++ b/src/main_world/test_broadcast_channel.js
@@ -2,6 +2,8 @@ export default function testBroadcastChannel (id) {
   const mainWorldId = `main world ${id}`;
   const channel = new BroadcastChannel('xkit_test');
   channel.addEventListener('message', (event) => {
-    console.log(`${mainWorldId} received message: ${event.data}`);
+    if (event.data.id === id) return;
+    const now = performance.timeOrigin + performance.now();
+    console.log(`${mainWorldId} received message: ${event.data.message}. delay: ${now - event.data.now}`);
   });
 }

--- a/src/main_world/test_broadcast_channel.js
+++ b/src/main_world/test_broadcast_channel.js
@@ -1,0 +1,7 @@
+export default function testBroadcastChannel (id) {
+  const mainWorldId = `main world ${id}`;
+  const channel = new BroadcastChannel('xkit_test');
+  channel.addEventListener('message', (event) => {
+    console.log(`${mainWorldId} received message: ${event.data}`);
+  });
+}

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -39,9 +39,45 @@ const id = Math.random();
 const contentScriptId = `content script ${id}`;
 const channel = new BroadcastChannel('xkit_test');
 channel.addEventListener('message', (event) => {
-  console.log(`${contentScriptId} received message: ${event.data}`);
+  if (event.data.id === id) return;
+  const now = performance.timeOrigin + performance.now();
+  console.log(`${contentScriptId} received message: ${event.data.message}. delay: ${now - event.data.now}`);
 });
 
 inject('/main_world/test_broadcast_channel.js', [contentScriptId]);
 
-setInterval(() => channel.postMessage(`message from ${contentScriptId}`), 3000);
+setInterval(
+  () =>
+    channel.postMessage({
+      id,
+      message: `message from ${contentScriptId}`,
+      now: performance.timeOrigin + performance.now(),
+    }),
+  3000,
+);
+
+// storage comparison
+
+const storageKey = 'TEST_AKWJDJKWN';
+
+const onStorageChanged = (changes) => {
+  if (Object.keys(changes).includes(storageKey)) {
+    const data = changes[storageKey].newValue;
+    const now = performance.timeOrigin + performance.now();
+    console.log(`${contentScriptId} received STORAGE message: ${data.message}. delay: ${now - data.now}`);
+  }
+};
+
+browser.storage.local.onChanged.addListener(onStorageChanged);
+
+setInterval(
+  () =>
+    browser.storage.local.set({
+      [storageKey]: {
+        id,
+        message: `message from ${contentScriptId}`,
+        now: performance.timeOrigin + performance.now(),
+      },
+    }),
+  3000,
+);

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -34,3 +34,14 @@ export const inject = (path, args = [], target = document.documentElement) =>
       new CustomEvent('xkit-injection-request', { detail: JSON.stringify(data), bubbles: true }),
     );
   });
+
+const id = Math.random();
+const contentScriptId = `content script ${id}`;
+const channel = new BroadcastChannel('xkit_test');
+channel.addEventListener('message', (event) => {
+  console.log(`${contentScriptId} received message: ${event.data}`);
+});
+
+inject('/main_world/test_broadcast_channel.js', [contentScriptId]);
+
+setInterval(() => channel.postMessage(`message from ${contentScriptId}`), 3000);


### PR DESCRIPTION
Broadcast channels in content scripts connect between the content scripts in all tumblr tabs and the main worlds in all tumblr tabs (excluding themself, obviously); they do not connect to extension pages. This is potentially quite useful for content script coordination behavior ("don't spam the API with interval refreshes if you have many tabs open"), assuming you're okay with page code being able to read the messages.

This is not useful for having the extension popup query tabs for Tumblr data. Of course, the extension popup has `browser.tabs.sendMessage()`, so there's no reason to be doing this in that case anyway.

Tested in Firefox and Chromium; haven't bothered with Safari.

Could be interesting to test: are these sort-of-synchronous? That is to say, if you send a message to the main world from the content script, then reply with a message back to the content script, does the message get received before the page is able to rerender? We know from using inject() to process new post elements that window.postMessage is **not** like this, causing flicker, and custom events **are** like this. I can't think of a reason why one would want to use this instead of custom events, so this is probably pointless, but it's academically interesting.